### PR TITLE
Changed kadira:flow-router by ostrio:flow-router-extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 This repository provides versions for the package [useraccounts:flow-routing](https://github.com/meteor-compat/useraccounts-flow-routing/) that are compatible with latest Meteor. This is necessary because the author is not maintaining package anymore.
 
-For who use `ostrio:flow-router-extra` instead of `kadira:flow-router`, the version 0.16.0 solve conflicts in production.
+For who use `ostrio:flow-router-extra` instead of `kadira:flow-router`, the version 2.0.0 solve conflicts in production.
 
 ## Changes
-- v1.16.0
-    - Changed dependency from `kadira:flow-router` to more recent package `ostrio:flow-router-extra`. 
+- v2.0.0
+    - Changed dependency from `kadira:flow-router` to more recent package `ostrio:flow-router-extra`. `kadira:flow-router` isn't supported by this version (use version 1.x.x)
 - v1.15.0
     - `api.versionsFrom` on `Package.onUse` was changed from `1.0.3` to `2.4`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 This repository provides versions for the package [useraccounts:flow-routing](https://github.com/meteor-compat/useraccounts-flow-routing/) that are compatible with latest Meteor. This is necessary because the author is not maintaining package anymore.
 
+For who use `ostrio:flow-router-extra` instead of `kadira:flow-router`, the version 0.16.0 solve conflicts in production.
+
 ## Changes
+- v1.16.0
+    - Changed dependency from `kadira:flow-router` to more recent package `ostrio:flow-router-extra`. 
 - v1.15.0
     - `api.versionsFrom` on `Package.onUse` was changed from `1.0.3` to `2.4`.
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -6,6 +6,7 @@
   $: false
 */
 'use strict';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 
 
 // Previous path used for redirect after form submit

--- a/lib/client/templates_helpers/at_input.js
+++ b/lib/client/templates_helpers/at_input.js
@@ -3,6 +3,7 @@
   FlowRouter: false
 */
 'use strict';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 
 AccountsTemplates.atInputRendered.push(function(){
   var fieldId = this.data._id;

--- a/lib/core.js
+++ b/lib/core.js
@@ -4,6 +4,7 @@
   FlowRouter: false
 */
 'use strict';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 
 // ---------------------------------------------------------------------------------
 

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@
 Package.describe({
   name: 'useraccounts:flow-routing',
   summary: 'UserAccounts package providing routes configuration capability via ostrio:flow-router-extra.',
-  version: '1.16.0',
+  version: '2.0.0',
   git: 'https://github.com/meteor-compat/useraccounts-flow-routing',
 });
 

--- a/package.js
+++ b/package.js
@@ -8,25 +8,22 @@
 
 Package.describe({
   name: 'useraccounts:flow-routing',
-  summary: 'UserAccounts package providing routes configuration capability via kadira:flow-router.',
-  version: '1.15.0',
+  summary: 'UserAccounts package providing routes configuration capability via ostrio:flow-router-extra.',
+  version: '1.16.0',
   git: 'https://github.com/meteor-compat/useraccounts-flow-routing',
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@2.4');
 
+  api.use('ecmascript');
+
   api.use([
     'check',
-    'kadira:flow-router',
+    'ostrio:flow-router-extra',
     'underscore',
     'useraccounts:core',
     'modules'
-  ], ['client', 'server']);
-
-  api.imply([
-    'kadira:flow-router@2.12.1',
-    'useraccounts:core@1.15.0',
   ], ['client', 'server']);
 
   api.use([


### PR DESCRIPTION
Version 0.15.0 works perfectly if the user is using `kadira:flow-router`. However, if he is using the recommended `ostrio:flow-router-extra`, there are some redirect bugs that only happen in production.

The test I did was run the application with meteor --production and I managed to replicate the problem exactly. So I changed the dependency of `kadira:flow-router` and made the necessary adjustments to make it work. Tested in version 2.5 of Meteor and with the latest `ostrio:flow-router-extra` version.

Users who want to continue using `kadira:flow-router` can continue using version 0.15.0